### PR TITLE
Use alloc nodes too in slurm partition gather info (AB#18521)

### DIFF
--- a/jupyterhub_moss/__init__.py
+++ b/jupyterhub_moss/__init__.py
@@ -3,7 +3,7 @@ from tornado.web import StaticFileHandler as _StaticFileHandler
 from .spawner import MOSlurmSpawner
 from .utils import local_path as _local_path
 
-version = "6.2.1"
+version = "6.2.2"
 
 STATIC_FORM_REGEX = r"/form/(.*)"
 STATIC_FORM_PATH = _local_path("form")

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -124,7 +124,7 @@ class MOSlurmSpawner(SlurmSpawner):
             ) = line.split()
 
             # ignore nodes that are full or down
-            if node_state not in ["idle", "mix"]:
+            if node_state not in ["idle", "mix", "alloc"]:
                 continue
 
             # core count - allocated/idle/other/total


### PR DESCRIPTION
Fix for issue in [AB#18521](https://dev.azure.com/VUB-ICT/3e951b95-f932-4cd3-9681-259422e2c681/_workitems/edit/18521)

If all nodes in a partition are 'alloc', it will give a key error on that partition but `_slurm_info_resources` will give no output on that partition.